### PR TITLE
Update xlf from resx: support adding translation units to previously empty xlf

### DIFF
--- a/XlfDocument.cs
+++ b/XlfDocument.cs
@@ -155,7 +155,8 @@ namespace xlflib
                             // source text changed
                             u.Source = resxData[key].Item1;
                             u.Optional.TargetState = "new";
-                            u.Optional.Notes.First().Value = resxData[key].Item2;
+                            u.Optional.SetCommentFromResx(resxData[key].Item2);
+
                             ++updatedItems;
                         }
                     }
@@ -183,7 +184,8 @@ namespace xlflib
                 {
                     var unit = f.AddTransUnit(d.Key, d.Value.Item1, d.Value.Item1);
                     unit.Optional.TargetState = "new";
-                    unit.Optional.Notes.First().Value = d.Value.Item2;
+                    unit.Optional.SetCommentFromResx(d.Value.Item2);
+                    
                     ++addedItems;
                 }
             }

--- a/XlfFile.cs
+++ b/XlfFile.cs
@@ -62,7 +62,30 @@ namespace xlflib
         public XlfTransUnit AddTransUnit(string id, string source, string target)
         {
             var n = new XElement(this.ns + "trans-unit");
-            this.node.Descendants(this.ns + "trans-unit").Last().AddAfterSelf(n);
+            var transUnits = this.node.Descendants(this.ns + "trans-unit").ToList();
+
+            if (transUnits.Any())
+            {
+                transUnits.Last().AddAfterSelf(n);
+            }
+            else
+            {
+                var bodyElements = this.node.Descendants(this.ns + "body").ToList();
+
+                XElement body;
+
+                if (bodyElements.Any())
+                {
+                    body = bodyElements.First();
+                }
+                else
+                {
+                    body = new XElement(this.ns + "body");
+                    this.node.Add(body);
+                }
+
+                body.Add(n);
+            }
 
             return new XlfTransUnit(n, this.ns, id, source, target);
         }

--- a/XlfTransUnit.cs
+++ b/XlfTransUnit.cs
@@ -144,6 +144,18 @@ namespace xlflib
                 AddNote(comment, string.Empty);
             }
 
+            public void SetCommentFromResx(string comment)
+            {
+                if (Notes.Any())
+                {
+                    Notes.First().Value = comment;
+                }
+                else
+                {
+                    AddNote(comment);
+                }
+            }
+
             private void RemoveNote(string attributeName, string value)
             {
                 this.node.Descendants(this.ns + "note").Where(u =>

--- a/XliffParserTest/FullResxEmptyXlifSample.cs
+++ b/XliffParserTest/FullResxEmptyXlifSample.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace XliffParserTest
+{
+    class ResxWithEmptyCorrespondingXlf : TestSample
+    {
+        public override string ResxContents =>
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<root>
+  <xsd:schema id=""root"" xmlns="""" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:msdata=""urn:schemas-microsoft-com:xml-msdata"">
+    <xsd:element name=""root"" msdata:IsDataSet=""true"">
+      <xsd:complexType>
+        <xsd:choice maxOccurs=""unbounded"">
+          <xsd:element name=""data"">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""1"" />
+                <xsd:element name=""comment"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""2"" />
+              </xsd:sequence>
+              <xsd:attribute name=""name"" type=""xsd:string"" msdata:Ordinal=""1"" />
+              <xsd:attribute name=""UESanitized"" type=""xsd:boolean"" msdata:Ordinal=""3"" />
+              <xsd:attribute name=""Visibility"" type=""Visibility_Type"" msdata:Ordinal=""4"" />
+              <xsd:attribute name=""type"" type=""xsd:string"" msdata:Ordinal=""5"" />
+              <xsd:attribute name=""mimetype"" type=""xsd:string"" msdata:Ordinal=""6"" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name=""resheader"">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""1"" />
+              </xsd:sequence>
+              <xsd:attribute name=""name"" type=""xsd:string"" use=""required"" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+    <xsd:simpleType name=""Visibility_Type"">
+      <xsd:restriction base=""xsd:string"">
+        <xsd:enumeration value=""Public"" />
+        <xsd:enumeration value=""Obsolete"" />
+        <xsd:enumeration value=""Private_OM"" />
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:schema>
+  <resheader name=""resmimetype"">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name=""version"">
+    <value>1.3</value>
+  </resheader>
+  <resheader name=""reader"">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name=""writer"">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name=""a"" UESanitized=""false"" Visibility=""Public"">
+    <value>Text for a</value>
+    <comment>Comment for a</comment>
+  </data>
+  <data name=""b"" UESanitized=""false"" Visibility=""Public"">
+    <value>Text for b</value>
+    <comment>Comment for b</comment>
+  </data>
+  <data name=""c"" UESanitized=""false"" Visibility=""Public"">
+    <value>Text for c</value>
+    <comment>Comment for c</comment>
+  </data>
+  <data name=""d"" UESanitized=""false"" Visibility=""Public"">
+    <value>Text for d</value>
+    <comment>Comment for d</comment>
+  </data>
+</root>";
+
+        public override string XlfContents =>
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<xliff version=""1.2"" xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""it"" original=""Strings.resx"">
+    <body>
+      <group id=""/RESOURCES/STRINGS.RESX"" datatype=""resx"" />
+    </body>
+  </file>
+</xliff>";
+    }
+}

--- a/XliffParserTest/ResxWithStaleCorrespondingXlf.cs
+++ b/XliffParserTest/ResxWithStaleCorrespondingXlf.cs
@@ -1,0 +1,105 @@
+using System;
+using XliffParserTest;
+
+namespace xlflib.Tests
+{
+    internal class ResxWithStaleCorrespondingXlf : TestSample
+    {
+        public override string ResxContents =>
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<root>
+  <xsd:schema id=""root"" xmlns="""" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:msdata=""urn:schemas-microsoft-com:xml-msdata"">
+    <xsd:element name=""root"" msdata:IsDataSet=""true"">
+      <xsd:complexType>
+        <xsd:choice maxOccurs=""unbounded"">
+          <xsd:element name=""data"">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""1"" />
+                <xsd:element name=""comment"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""2"" />
+              </xsd:sequence>
+              <xsd:attribute name=""name"" type=""xsd:string"" msdata:Ordinal=""1"" />
+              <xsd:attribute name=""UESanitized"" type=""xsd:boolean"" msdata:Ordinal=""3"" />
+              <xsd:attribute name=""Visibility"" type=""Visibility_Type"" msdata:Ordinal=""4"" />
+              <xsd:attribute name=""type"" type=""xsd:string"" msdata:Ordinal=""5"" />
+              <xsd:attribute name=""mimetype"" type=""xsd:string"" msdata:Ordinal=""6"" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name=""resheader"">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""1"" />
+              </xsd:sequence>
+              <xsd:attribute name=""name"" type=""xsd:string"" use=""required"" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+    <xsd:simpleType name=""Visibility_Type"">
+      <xsd:restriction base=""xsd:string"">
+        <xsd:enumeration value=""Public"" />
+        <xsd:enumeration value=""Obsolete"" />
+        <xsd:enumeration value=""Private_OM"" />
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:schema>
+  <resheader name=""resmimetype"">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name=""version"">
+    <value>1.3</value>
+  </resheader>
+  <resheader name=""reader"">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name=""writer"">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name=""a"" UESanitized=""false"" Visibility=""Public"">
+    <value>Text for a</value>
+    <comment>Comment for a</comment>
+  </data>
+  <data name=""b"" UESanitized=""false"" Visibility=""Public"">
+    <value>Text for b</value>
+    <comment>Comment for b</comment>
+  </data>
+  <data name=""c"" UESanitized=""false"" Visibility=""Public"">
+    <value>Text for c</value>
+    <comment>Comment for c</comment>
+  </data>
+  <data name=""d"" UESanitized=""false"" Visibility=""Public"">
+    <value>Text for d</value>
+    <comment>Comment for d</comment>
+  </data>
+</root>";
+
+        public override string XlfContents =>
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<xliff version=""1.2"">
+ <file original=""Strings.resx""
+  source-language=""en-US"" target-language=""ja-JP""
+  >
+  <body>
+   <trans-unit id=""a"" maxbytes=""14"">
+    <source xml:lang=""en-US"">Text for a</source>
+    <target xml:lang=""ja-JP"">Translation</target>
+    <note from="""" annotates=""source"" priority=""4"">Comment for a</note>
+   </trans-unit>
+   <trans-unit id=""b"" maxbytes=""14"">
+    <source xml:lang=""en-US"">stale</source>
+    <target xml:lang=""ja-JP"">Translation</target>
+   </trans-unit>
+   <trans-unit id=""c"" maxbytes=""14"">
+    <source xml:lang=""en-US"">stale</source>
+    <target xml:lang=""ja-JP"">Translation</target>
+   </trans-unit>
+   <trans-unit id=""e"" maxbytes=""14"">
+    <source xml:lang=""en-US"">Text for e</source>
+    <target xml:lang=""ja-JP"">Translation</target>
+   </trans-unit>
+  </body>
+ </file>
+</xliff>";
+    }
+}

--- a/XliffParserTest/TestSample.cs
+++ b/XliffParserTest/TestSample.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.IO;
+
+namespace XliffParserTest
+{
+    internal abstract class TestSample: IDisposable
+    {
+        protected static readonly string RootTestPath = Path.GetTempPath() +  "XlifParserTempTestData";
+
+        protected Guid SampleGuid { get; }
+
+        public abstract string ResxContents { get; }
+
+        public abstract string XlfContents { get; }
+
+        public string ResxFileName { get; }
+
+        public string XlfFileName { get; }
+
+        protected TestSample()
+        {
+            SampleGuid = Guid.NewGuid();
+
+            if (!Directory.Exists(RootTestPath))
+            {
+                Directory.CreateDirectory(RootTestPath);
+            }
+
+            ResxFileName = Path.Combine(Path.GetTempPath(), RootTestPath, "Resx_" + SampleGuid);
+            File.WriteAllText(ResxFileName, ResxContents);
+
+            XlfFileName = Path.Combine(Path.GetTempPath(), RootTestPath, "Xlf_" + SampleGuid);
+            File.WriteAllText(XlfFileName, XlfContents);
+        }
+
+        ~TestSample() { Dispose(false); }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                GC.SuppressFinalize(this);
+            }
+
+            try
+            {
+                if (File.Exists(ResxFileName))
+                {
+                    File.Delete(ResxFileName);
+                }
+
+                if (File.Exists(XlfFileName))
+                {
+                    File.Delete(XlfFileName);
+                }
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine("Exception thrown in TestSample Dispose:\n" + e);
+            }
+        }
+    }
+}

--- a/XliffParserTest/XlfDocumentTests.cs
+++ b/XliffParserTest/XlfDocumentTests.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using XliffParserTest;
+
+namespace xlflib.Tests
+{
+    [TestClass()]
+    public class XlfDocumentTests
+    {
+        [TestMethod()]
+        public void UpdateEmptyXlfFromResx()
+        {
+            using (var sample = new ResxWithEmptyCorrespondingXlf())
+            {
+                var xlfDocument = new XlfDocument(sample.XlfFileName);
+                var updateResult = xlfDocument.UpdateFromResX(sample.ResxFileName);
+
+                Assert.AreEqual(0, updateResult.Item1);
+                Assert.AreEqual(4, updateResult.Item2);
+                Assert.AreEqual(0, updateResult.Item3);
+
+                var xlfTransUnits = xlfDocument.Files.SelectMany(f => f.TransUnits).ToDictionary(tu => tu.Id, tu => tu);
+
+                Assert.AreEqual(4, xlfTransUnits.Count);
+
+                AssertTranslationUnit(xlfTransUnits, "a", "Text for a", "Text for a", "Comment for a", "new");
+                AssertTranslationUnit(xlfTransUnits, "b", "Text for b", "Text for b", "Comment for b", "new");
+                AssertTranslationUnit(xlfTransUnits, "c", "Text for c", "Text for c", "Comment for c", "new");
+                AssertTranslationUnit(xlfTransUnits, "d", "Text for d", "Text for d", "Comment for d", "new");
+            }
+        }
+
+        [TestMethod()]
+        public void UpdateStaleXlfFromResx()
+        {
+            using (var sample = new ResxWithStaleCorrespondingXlf())
+            {
+                var xlfDocument = new XlfDocument(sample.XlfFileName);
+                var updateResult = xlfDocument.UpdateFromResX(sample.ResxFileName);
+
+                Assert.AreEqual(2, updateResult.Item1);
+                Assert.AreEqual(1, updateResult.Item2);
+                Assert.AreEqual(1, updateResult.Item3);
+
+                var xlfTransUnits = xlfDocument.Files.SelectMany(f => f.TransUnits).ToDictionary(tu => tu.Id, tu => tu);
+
+                Assert.AreEqual(4, xlfTransUnits.Count);
+
+                AssertTranslationUnit(xlfTransUnits, "a", "Text for a", "Translation", "Comment for a", null);
+                AssertTranslationUnit(xlfTransUnits, "b", "Text for b", "Translation", "Comment for b", "new");
+                AssertTranslationUnit(xlfTransUnits, "c", "Text for c", "Translation", "Comment for c", "new");
+                AssertTranslationUnit(xlfTransUnits, "d", "Text for d", "Text for d", "Comment for d", "new");
+            }
+        }
+
+        private static void AssertTranslationUnit(Dictionary<string, XlfTransUnit> xlfTransUnits, string id, string source, string target, string comment, string targetState)
+        {
+            Assert.IsTrue(xlfTransUnits.ContainsKey(id));
+            var unit = xlfTransUnits[id];
+
+            Assert.AreEqual(source, unit.Source);
+            Assert.AreEqual(target, unit.Target);
+            Assert.IsTrue(unit.Optional.Notes.Any());
+            Assert.AreEqual(comment, unit.Optional.Notes.First().Value);
+            Assert.AreEqual(targetState ?? string.Empty, unit.Optional.TargetState);
+        }
+    }
+}

--- a/XliffParserTest/XliffParserTest.csproj
+++ b/XliffParserTest/XliffParserTest.csproj
@@ -53,7 +53,11 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="FullResxEmptyXlifSample.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ResxWithStaleCorrespondingXlf.cs" />
+    <Compile Include="TestSample.cs" />
+    <Compile Include="XlfDocumentTests.cs" />
     <Compile Include="XlfTransUnitTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Also added some tests for this scenario.

I am working on creating localized builds for the [msbuild](https://github.com/Microsoft/msbuild/tree/master) repository and storing the resources in xlf. We had a bunch of resx files and needed xlfs. Easiest way to generate them was to create stub xlfs files and then modify XliffParser to be able to update an empty xlf file from a .resx.
