### PR TITLE
Introduce overload to UpdateFromResX to set state strings

### DIFF
--- a/XlfDocument.cs
+++ b/XlfDocument.cs
@@ -118,11 +118,23 @@ namespace xlflib
         }
 
         /// <summary>
-        ///
+        /// Uses "new" as the state for updated and new strings
         /// </summary>
         /// <param name="fileName"></param>
         /// <returns>Return the number of updated/added/removed items</returns>
         public Tuple<int, int, int> UpdateFromResX(string fileName)
+        {
+            return UpdateFromResX(fileName, "new", "new");
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <param name="updatedResourceStateString"></param>
+        /// <param name="addedResourceStateString"></param>
+        /// <returns>Return the number of updated/added/removed items</returns>
+        public Tuple<int, int, int> UpdateFromResX(string fileName, string updatedResourceStateString, string addedResourceStateString)
         {
             var resxData = new Dictionary<string, Tuple<string, string>>(); // name, data, comment
             using (var resx = new ResXResourceReader(fileName))
@@ -154,7 +166,7 @@ namespace xlflib
                         {
                             // source text changed
                             u.Source = resxData[key].Item1;
-                            u.Optional.TargetState = "new";
+                            u.Optional.TargetState = updatedResourceStateString;
                             u.Optional.SetCommentFromResx(resxData[key].Item2);
 
                             ++updatedItems;
@@ -183,9 +195,9 @@ namespace xlflib
                 foreach (var d in resxData)
                 {
                     var unit = f.AddTransUnit(d.Key, d.Value.Item1, d.Value.Item1);
-                    unit.Optional.TargetState = "new";
+                    unit.Optional.TargetState = addedResourceStateString;
                     unit.Optional.SetCommentFromResx(d.Value.Item2);
-                    
+
                     ++addedItems;
                 }
             }

--- a/XliffParserTest/XlfDocumentTests.cs
+++ b/XliffParserTest/XlfDocumentTests.cs
@@ -54,6 +54,29 @@ namespace xlflib.Tests
             }
         }
 
+        [TestMethod()]
+        public void UpdateStaleXlfFromResxWithCustomStateStrings()
+        {
+            using (var sample = new ResxWithStaleCorrespondingXlf())
+            {
+                var xlfDocument = new XlfDocument(sample.XlfFileName);
+                var updateResult = xlfDocument.UpdateFromResX(sample.ResxFileName, "foo", "bar");
+
+                Assert.AreEqual(2, updateResult.Item1);
+                Assert.AreEqual(1, updateResult.Item2);
+                Assert.AreEqual(1, updateResult.Item3);
+
+                var xlfTransUnits = xlfDocument.Files.SelectMany(f => f.TransUnits).ToDictionary(tu => tu.Id, tu => tu);
+
+                Assert.AreEqual(4, xlfTransUnits.Count);
+
+                AssertTranslationUnit(xlfTransUnits, "a", "Text for a", "Translation", "Comment for a", null);
+                AssertTranslationUnit(xlfTransUnits, "b", "Text for b", "Translation", "Comment for b", "foo");
+                AssertTranslationUnit(xlfTransUnits, "c", "Text for c", "Translation", "Comment for c", "foo");
+                AssertTranslationUnit(xlfTransUnits, "d", "Text for d", "Text for d", "Comment for d", "bar");
+            }
+        }
+
         private static void AssertTranslationUnit(Dictionary<string, XlfTransUnit> xlfTransUnits, string id, string source, string target, string comment, string targetState)
         {
             Assert.IsTrue(xlfTransUnits.ContainsKey(id));


### PR DESCRIPTION
Different workflows / tools might require different strings. They need to be able to be specified to the method that does the update.

In our case, updated strings are handled differently than new strings, so the updated xlf needs to be able to differentiate between the two.
